### PR TITLE
Add user attributes to users table

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,12 @@ import_config "#{Mix.env()}.exs"
 
 config :ueberauth, Ueberauth,
   providers: [
-    facebook: {Ueberauth.Strategy.Facebook, []}
+    facebook:
+      {Ueberauth.Strategy.Facebook,
+       [
+         profile_fields: "id,email,first_name,last_name,gender,location",
+         default_scope: "email,public_profile"
+       ]}
   ]
 
 config :ueberauth, Ueberauth.Strategy.Facebook.OAuth,

--- a/lib/travenger/accounts/user.ex
+++ b/lib/travenger/accounts/user.ex
@@ -13,7 +13,11 @@ defmodule Travenger.Accounts.User do
     field(:email, :string)
     field(:provider, :string)
     field(:token, :string)
+    # user info
     field(:image_url, :string)
+    field(:first_name, :string)
+    field(:last_name, :string)
+    field(:gender, :string)
 
     has_many(:groups, Group)
     has_many(:events, Event)
@@ -22,7 +26,7 @@ defmodule Travenger.Accounts.User do
     timestamps()
   end
 
-  @user_attrs ~w(email token provider image_url)a
+  @user_attrs ~w(email token provider image_url first_name last_name gender)a
 
   @doc false
   def changeset(user, attrs) do

--- a/lib/travenger/groups/group.ex
+++ b/lib/travenger/groups/group.ex
@@ -1,10 +1,15 @@
 defmodule Travenger.Groups.Group do
   use Ecto.Schema
+
   import Ecto.Changeset
+
+  alias Travenger.Posts.Event
 
   schema "groups" do
     field(:name, :string)
+    field(:image_url, :string)
 
+    has_many(:events, Event)
     timestamps()
   end
 

--- a/lib/travenger_web/controllers/auth_controller.ex
+++ b/lib/travenger_web/controllers/auth_controller.ex
@@ -7,13 +7,18 @@ defmodule TravengerWeb.AuthController do
   plug(Ueberauth)
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, params) do
-    with params <- string_keys_to_atom(params) do
+    with params <- string_keys_to_atom(params),
+         user_info <- string_keys_to_atom(auth.extra.raw_info.user) do
       params =
         params
         |> Map.put(:token, auth.credentials.token)
         |> Map.put(:email, auth.info.email)
         |> Map.put(:image_url, auth.info.image)
+        |> Map.put(:first_name, auth.info.first_name)
+        |> Map.put(:last_name, auth.info.last_name)
+        |> Map.put(:gender, user_info.gender)
 
+      IO.inspect(params)
       authenticate_or_register(conn, params)
     end
   end

--- a/priv/repo/migrations/20180617062025_add_user_info_to_users_table.exs
+++ b/priv/repo/migrations/20180617062025_add_user_info_to_users_table.exs
@@ -1,0 +1,11 @@
+defmodule Travenger.Repo.Migrations.AddUserInfoToUsersTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:first_name, :string)
+      add(:last_name, :string)
+      add(:gender, :string)
+    end
+  end
+end

--- a/test/travenger_web/controllers/auth_controller_test.exs
+++ b/test/travenger_web/controllers/auth_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule TravengerWeb.BlogControllerTest do
+  use TravengerWeb.ConnCase
+
+  test "Sign in with Facebook", %{conn: conn} do
+    conn = get(conn, "/auth/facebook?scope=email,public_profile")
+    assert redirected_to(conn, 302)
+  end
+end


### PR DESCRIPTION
This PR puts additional attributes to user schema including first name, last name, and gender. It also catches new attributes from Facebook access token.