### PR TITLE
✨ Add rest endpoint for approve join request

### DIFF
--- a/lib/travenger/accounts/membership.ex
+++ b/lib/travenger/accounts/membership.ex
@@ -46,6 +46,7 @@ defmodule Travenger.Accounts.Membership do
   def approve_changeset(membership) do
     membership
     |> change()
+    |> cast_assoc(:membership_status)
     |> put_change(:role, :member)
   end
 

--- a/lib/travenger/helpers/queries.ex
+++ b/lib/travenger/helpers/queries.ex
@@ -32,4 +32,16 @@ defmodule Travenger.Helpers.Queries do
   end
 
   def where_gender(query, _params), do: query
+
+  def where_group(query, %{group_id: gid}) do
+    where(query, [q], q.group_id == ^gid)
+  end
+
+  def where_group(query, _params), do: query
+
+  def where_user(query, %{user_id: uid}) do
+    where(query, [q], q.user_id == ^uid)
+  end
+
+  def where_user(query, _params), do: query
 end

--- a/lib/travenger/helpers/queries/membership.ex
+++ b/lib/travenger/helpers/queries/membership.ex
@@ -1,0 +1,10 @@
+defmodule Travenger.Helpers.Queries.Membership do
+  @moduledoc """
+  Membership Queries helper
+  """
+  import Ecto.Query
+
+  def where_admin(query, _params) do
+    where(query, [q], q.role == ^:creator or q.role == ^:admin)
+  end
+end

--- a/lib/travenger_web/controllers/group_controller.ex
+++ b/lib/travenger_web/controllers/group_controller.ex
@@ -18,9 +18,8 @@ defmodule TravengerWeb.GroupController do
     end
   end
 
-  def join(%{assigns: %{user: user}} = conn, params) do
-    with %{id: group_id} <- string_keys_to_atom(params),
-         %Group{} = group <- Groups.get_group(group_id),
+  def join(%{assigns: %{user: user}} = conn, %{"group_id" => gid}) do
+    with %Group{} = group <- Groups.get_group(gid),
          {:ok, membership} <- Groups.join_group(user, group) do
       conn
       |> put_status(:ok)

--- a/lib/travenger_web/controllers/membership_controller.ex
+++ b/lib/travenger_web/controllers/membership_controller.ex
@@ -1,0 +1,23 @@
+defmodule TravengerWeb.MembershipController do
+  use TravengerWeb, :controller
+
+  import Travenger.Helpers.Utils
+
+  alias Travenger.Accounts.Membership
+  alias Travenger.Groups
+  alias TravengerWeb.MembershipView
+
+  plug(Travenger.Plugs.RequireAuth when action in [:approve])
+  plug(Travenger.Plugs.CheckGroupAdmin when action in [:approve])
+
+  def approve(conn, params) do
+    with %{membership_id: m_id} <- string_keys_to_atom(params),
+         %Membership{} = membership <- Groups.get_membership(m_id),
+         {:ok, membership} <- Groups.approve_join_request(membership) do
+      conn
+      |> put_status(:ok)
+      |> put_view(MembershipView)
+      |> render("show.json", membership: membership)
+    end
+  end
+end

--- a/lib/travenger_web/plugs/check_group_admin.ex
+++ b/lib/travenger_web/plugs/check_group_admin.ex
@@ -1,0 +1,32 @@
+defmodule Travenger.Plugs.CheckGroupAdmin do
+  @moduledoc """
+  Plug for checking if the current user is authorized to access the group
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+  import Travenger.Helpers.Utils
+
+  alias Phoenix.Controller
+  alias Travenger.Groups
+  alias TravengerWeb.ErrorView
+
+  def init(opts), do: opts
+
+  def call(%{assigns: %{user: user}} = conn, _) do
+    string_keys_to_atom(conn.params)
+    |> Map.put(:user_id, user.id)
+    |> Groups.find_group_admin()
+    |> case do
+      nil ->
+        conn
+        |> put_status(403)
+        |> Controller.render(ErrorView, "403.json")
+        |> halt()
+
+      _ ->
+        conn
+    end
+  end
+end

--- a/lib/travenger_web/router.ex
+++ b/lib/travenger_web/router.ex
@@ -26,8 +26,14 @@ defmodule TravengerWeb.Router do
     resources("/blogs", BlogController)
     resources("/users", UserController)
 
-    post("/groups/:id/join", GroupController, :join)
-    resources("/groups", GroupController)
+    resources("/groups", GroupController) do
+      post("/join", GroupController, :join)
+
+      resources("/memberships", MembershipController) do
+        put("/approve", MembershipController, :approve)
+      end
+    end
+
     resources("/events", EventController)
   end
 

--- a/lib/travenger_web/views/error_view.ex
+++ b/lib/travenger_web/views/error_view.ex
@@ -13,10 +13,19 @@ defmodule TravengerWeb.ErrorView do
     title: "Unauthorized"
   }
 
+  @forbidden %{
+    status: "403",
+    title: "Forbidden"
+  }
+
   # JSON errors
 
   def render("401.json", _assigns) do
     %{errors: [@unauthorized]}
+  end
+
+  def render("403.json", _assigns) do
+    %{errors: [@forbidden]}
   end
 
   def render("404.json", _assigns) do

--- a/test/travenger/groups/groups_test.exs
+++ b/test/travenger/groups/groups_test.exs
@@ -81,15 +81,16 @@ defmodule Travenger.GroupsTest do
   describe "approve_join_request/1" do
     setup do
       membership = insert(:membership)
-      {:ok, membership_status} = Groups.approve_join_request(membership)
+      {:ok, membership} = Groups.approve_join_request(membership)
 
-      %{membership_status: membership_status}
+      %{membership: membership}
     end
 
-    test "approves a pending group membership request", %{membership_status: mstatus} do
-      assert mstatus.id
-      assert mstatus.approved_at
-      assert mstatus.status == :approved
+    test "approves a pending group membership request", %{membership: membership} do
+      assert membership.id
+      assert membership.role == :member
+      assert membership.membership_status.status == :approved
+      assert membership.membership_status.approved_at
     end
   end
 end

--- a/test/travenger_web/controllers/group_controller_test.exs
+++ b/test/travenger_web/controllers/group_controller_test.exs
@@ -44,7 +44,7 @@ defmodule TravengerWeb.GroupControllerTest do
   describe "join/2" do
     setup %{conn: conn} do
       group = insert(:group)
-      conn = post(conn, group_path(conn, :join, group.id))
+      conn = post(conn, group_group_path(conn, :join, group.id))
       %{assigns: %{membership: membership}} = conn
 
       %{membership: membership, conn: conn}
@@ -61,7 +61,7 @@ defmodule TravengerWeb.GroupControllerTest do
     test "returns error if user is not authenticated" do
       group = insert(:group)
       conn = build_conn()
-      conn = post(conn, group_path(conn, :join, group.id))
+      conn = post(conn, group_group_path(conn, :join, group.id))
       assert json_response(conn, 401)["errors"] == @unauthorized_error_code
     end
   end

--- a/test/travenger_web/controllers/membership_controller_test.exs
+++ b/test/travenger_web/controllers/membership_controller_test.exs
@@ -1,0 +1,64 @@
+defmodule TravengerWeb.MembershipControllerTest do
+  @moduledoc """
+  Tests for Group Controller functions
+  """
+  use TravengerWeb.ConnCase
+
+  import Travenger.Factory
+  import Travenger.TestHelpers
+
+  alias TravengerWeb.MembershipView
+
+  @unauthorized_error_code [%{"status" => "401", "title" => "Unauthorized"}]
+  @forbidden_error_code [%{"status" => "403", "title" => "Forbidden"}]
+
+  setup do
+    user = insert(:user)
+    conn = build_user_conn(user, &build_conn/0, &put_req_header/3)
+    %{conn: conn, user: user}
+  end
+
+  describe "approve/2" do
+    setup %{conn: conn, user: user} do
+      grp = insert(:group)
+      insert(:membership, user: user, group: grp, role: :creator)
+      m = insert(:membership, group: grp)
+      path = group_membership_membership_path(conn, :approve, grp.id, m.id)
+      conn = put(conn, path)
+      %{assigns: %{membership: membership}} = conn
+
+      %{membership: membership, conn: conn, group: grp}
+    end
+
+    test "returns a membership with role member", %{membership: m, conn: conn} do
+      expected = render_json(MembershipView, "show.json", %{membership: m})
+      assert json_response(conn, :ok) == expected
+    end
+
+    test "returns error when user is not authenticated", %{
+      group: g,
+      membership: m
+    } do
+      conn = build_conn()
+      path = group_membership_membership_path(conn, :approve, g.id, m.id)
+      conn = put(conn, path)
+      assert json_response(conn, 401)["errors"] == @unauthorized_error_code
+    end
+  end
+
+  describe "approve/2 when current user is not creator/admin" do
+    setup %{conn: conn, user: user} do
+      grp = insert(:group)
+      insert(:membership, user: user, group: grp, role: :member)
+      m = insert(:membership, group: grp)
+      path = group_membership_membership_path(conn, :approve, grp.id, m.id)
+      conn = put(conn, path)
+
+      %{conn: conn}
+    end
+
+    test "returns error", %{conn: conn} do
+      assert json_response(conn, 403)["errors"] == @forbidden_error_code
+    end
+  end
+end


### PR DESCRIPTION
This PR also includes the following changes:
- [x] refactor approve_join_request library function to output `{:ok, membership}`
- [x] update tests in accordance to above changes
- [x] add check_group_admin plug for checking if the current user is the creator/admin of the group