### PR TITLE
✨[Feature] Delete Group

### DIFF
--- a/lib/travenger/groups/group.ex
+++ b/lib/travenger/groups/group.ex
@@ -46,6 +46,12 @@ defmodule Travenger.Groups.Group do
     |> cast(attrs, @group_attrs)
   end
 
+  def delete_changeset(group, attrs \\ %{}) do
+    group
+    |> cast(attrs, [])
+    |> put_change(:deleted_at, DateTime.utc_now())
+  end
+
   defp put_member(ch) do
     put_assoc(ch, :members, [
       %Membership{

--- a/lib/travenger/groups/group.ex
+++ b/lib/travenger/groups/group.ex
@@ -22,6 +22,8 @@ defmodule Travenger.Groups.Group do
     field(:image_url, :string)
     field(:description, :string)
 
+    field(:deleted_at, :naive_datetime)
+
     belongs_to(:user, User)
     has_many(:members, Membership)
     has_many(:events, Event)

--- a/lib/travenger/groups/groups.ex
+++ b/lib/travenger/groups/groups.ex
@@ -40,6 +40,24 @@ defmodule Travenger.Groups do
   end
 
   @doc """
+  Deletes a Group. Updates deleted_at.
+
+  ## Examples
+
+      iex> delete_group(group)
+      {:ok, %Group{}}
+
+      iex> delete_group(group)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_group(%Group{} = group) do
+    group
+    |> Group.delete_changeset()
+    |> Repo.update()
+  end
+
+  @doc """
   Gets a single group.
 
   Raises `Ecto.NoResultsError` if the Group does not exist.
@@ -83,22 +101,6 @@ defmodule Travenger.Groups do
     group
     |> Group.update_changeset(attrs)
     |> Repo.update()
-  end
-
-  @doc """
-  Deletes a Group.
-
-  ## Examples
-
-      iex> delete_group(group)
-      {:ok, %Group{}}
-
-      iex> delete_group(group)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_group(%Group{} = group) do
-    Repo.delete(group)
   end
 
   @doc """

--- a/lib/travenger/groups/groups.ex
+++ b/lib/travenger/groups/groups.ex
@@ -36,6 +36,7 @@ defmodule Travenger.Groups do
     |> where_keyword(params)
     |> where_name(params)
     |> where_user(params)
+    |> where_not_deleted(params)
     |> Repo.paginate(params)
   end
 
@@ -71,7 +72,14 @@ defmodule Travenger.Groups do
       ** (Ecto.NoResultsError)
 
   """
-  def get_group(id), do: Repo.get(Group, id)
+  def get_group(id) do
+    params = %{id: id}
+
+    Group
+    |> where_id(params)
+    |> where_not_deleted(params)
+    |> Repo.one()
+  end
 
   @doc """
   Creates a group.

--- a/lib/travenger/helpers/queries.ex
+++ b/lib/travenger/helpers/queries.ex
@@ -62,4 +62,8 @@ defmodule Travenger.Helpers.Queries do
   end
 
   def where_type(query, _params), do: query
+
+  def where_not_deleted(query, _) do
+    where(query, [q], is_nil(q.deleted_at))
+  end
 end

--- a/priv/repo/migrations/20181013030655_add-deleted-at-in-groups.exs
+++ b/priv/repo/migrations/20181013030655_add-deleted-at-in-groups.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Travenger.Repo.Migrations.Add-deleted-at-in-groups" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:groups) do
+      add(:deleted_at, :naive_datetime)
+    end
+  end
+end

--- a/test/travenger/groups/group_test.exs
+++ b/test/travenger/groups/group_test.exs
@@ -35,4 +35,13 @@ defmodule Travenger.Groups.GroupTest do
       assert ch.valid?
     end
   end
+
+  describe "delete_changeset/2" do
+    test "returns a valid changeset" do
+      ch = Group.delete_changeset(build(:group))
+
+      assert ch.valid?
+      assert ch.changes[:deleted_at]
+    end
+  end
 end

--- a/test/travenger/groups/groups_test.exs
+++ b/test/travenger/groups/groups_test.exs
@@ -211,6 +211,7 @@ defmodule Travenger.GroupsTest do
   describe "list_groups/1" do
     setup %{user: user} do
       group = insert(:group, user: user, name: "Sample Travel Group")
+      insert(:group, deleted_at: DateTime.utc_now())
       insert(:group)
 
       %{group: group}
@@ -220,6 +221,12 @@ defmodule Travenger.GroupsTest do
       %{total_entries: total} = Groups.list_groups()
 
       assert total == 2
+    end
+
+    test "list all groups excluding deleted_at" do
+      %{entries: entries} = Groups.list_groups()
+
+      assert Enum.all?(entries, &is_nil(&1.deleted_at))
     end
 
     test "filter by creator", %{user: user} do
@@ -254,6 +261,18 @@ defmodule Travenger.GroupsTest do
 
       assert group.id
       refute is_nil(group.deleted_at)
+    end
+  end
+
+  describe "get_group/1" do
+    test "returns a group" do
+      group = insert(:group)
+      assert Groups.get_group(group.id)
+    end
+
+    test "does not return deleted group" do
+      group = insert(:group, deleted_at: DateTime.utc_now())
+      refute Groups.get_group(group.id)
     end
   end
 end

--- a/test/travenger/groups/groups_test.exs
+++ b/test/travenger/groups/groups_test.exs
@@ -246,4 +246,14 @@ defmodule Travenger.GroupsTest do
       assert Enum.any?(groups, fn group -> group.name == grp.name end)
     end
   end
+
+  describe "delete_group/1" do
+    test "updates deleted_at" do
+      group = insert(:group)
+      {:ok, group} = Groups.delete_group(group)
+
+      assert group.id
+      refute is_nil(group.deleted_at)
+    end
+  end
 end


### PR DESCRIPTION
This PR implements a new feature `delete_group`. This does not totally delete the group in the database but only updates the `deleted_at` field.

Reference to Issue #8 