### PR TITLE
[Feature] Assign Member as Admin

### DIFF
--- a/lib/travenger/accounts/membership.ex
+++ b/lib/travenger/accounts/membership.ex
@@ -62,6 +62,20 @@ defmodule Travenger.Accounts.Membership do
     |> put_invited_status()
   end
 
+  def assign_admin_changeset(membership, attrs \\ %{}) do
+    membership
+    |> cast(attrs, [:role])
+    |> validate_role([:member])
+    |> put_change(:role, :admin)
+  end
+
+  defp validate_role(ch, valid_status) when is_list(valid_status) do
+    case get_field(ch, :role) in valid_status do
+      false -> add_error(ch, :role, "is invalid")
+      _ -> ch
+    end
+  end
+
   defp put_invited_status(ch) do
     put_assoc(ch, :membership_status, %MembershipStatus{
       status: :invited,

--- a/lib/travenger/groups/groups.ex
+++ b/lib/travenger/groups/groups.ex
@@ -227,6 +227,21 @@ defmodule Travenger.Groups do
   def invite(%User{}, _), do: {:error, "invalid group"}
   def invite(_, _), do: {:error, "invalid user and group"}
 
+  @doc """
+  Assign a member as an admin
+  """
+  def assign_admin(%Membership{} = membership) do
+    membership
+    |> Repo.preload([:group, :user, :membership_status])
+    |> Membership.assign_admin_changeset()
+    |> Repo.update()
+  end
+
+  def assign_admin(_), do: {:error, "invalid membership"}
+
+  @doc """
+  Checks whether the groups has reached max members or not yet
+  """
   def is_full?(_, %Group{member_limit: limit} = group) do
     case count_members(group) == limit do
       true -> {:error, "maximum number of members reached"}

--- a/lib/travenger_web/controllers/api/v1/membership_controller.ex
+++ b/lib/travenger_web/controllers/api/v1/membership_controller.ex
@@ -7,13 +7,26 @@ defmodule TravengerWeb.Api.V1.MembershipController do
   alias Travenger.Groups
   alias TravengerWeb.Api.V1.MembershipView
 
-  plug(Travenger.Plugs.RequireAuth when action in [:approve])
-  plug(Travenger.Plugs.CheckGroupAdmin when action in [:approve])
+  @require_auth_functions ~w(approve assign_admin)a
+  @require_admin_functions ~w(approve assign_admin)a
+
+  plug(Travenger.Plugs.RequireAuth when action in @require_auth_functions)
+  plug(Travenger.Plugs.CheckGroupAdmin when action in @require_admin_functions)
 
   def approve(conn, params) do
     with %{membership_id: m_id} <- string_keys_to_atom(params),
          %Membership{} = membership <- Groups.get_membership(m_id),
          {:ok, membership} <- Groups.approve_join_request(membership) do
+      conn
+      |> put_status(:ok)
+      |> put_view(MembershipView)
+      |> render("show.json", membership: membership)
+    end
+  end
+
+  def assign_admin(conn, %{"membership_id" => id}) do
+    with %Membership{} = membership <- Groups.get_membership(id),
+         {:ok, membership} <- Groups.assign_admin(membership) do
       conn
       |> put_status(:ok)
       |> put_view(MembershipView)

--- a/lib/travenger_web/router.ex
+++ b/lib/travenger_web/router.ex
@@ -42,6 +42,7 @@ defmodule TravengerWeb.Router do
 
         resources("/memberships", MembershipController) do
           put("/approve", MembershipController, :approve)
+          put("/assign-admin", MembershipController, :assign_admin)
         end
       end
     end

--- a/test/travenger/accounts/membership_test.exs
+++ b/test/travenger/accounts/membership_test.exs
@@ -64,4 +64,22 @@ defmodule Travenger.Accounts.MembershipTest do
       assert ch.changes[:membership_status]
     end
   end
+
+  describe "assign_admin_changeset/2" do
+    test "returns a valid changeset" do
+      membership = build(:membership, role: :member)
+      ch = Membership.assign_admin_changeset(membership)
+
+      assert ch.valid?
+      assert ch.changes[:role] == :admin
+    end
+
+    test "returns invalid changeset if status is invalid" do
+      membership = build(:membership, role: :waiting)
+      ch = Membership.assign_admin_changeset(membership)
+
+      refute ch.valid?
+      assert ch.errors == [role: {"is invalid", []}]
+    end
+  end
 end

--- a/test/travenger/groups/groups_test.exs
+++ b/test/travenger/groups/groups_test.exs
@@ -329,4 +329,20 @@ defmodule Travenger.GroupsTest do
       refute Groups.get_group(group.id)
     end
   end
+
+  describe "assign_admin/1" do
+    test "returns a membership with admin role" do
+      membership = insert(:membership, role: :member)
+      {:ok, membership} = Groups.assign_admin(membership)
+
+      assert membership.id
+      assert membership.role == :admin
+    end
+
+    test "return error for invalid membership" do
+      {:error, error} = Groups.assign_admin(nil)
+
+      assert error == "invalid membership"
+    end
+  end
 end

--- a/test/travenger_web/controllers/api/v1/membership_controller_test.exs
+++ b/test/travenger_web/controllers/api/v1/membership_controller_test.exs
@@ -77,4 +77,66 @@ defmodule TravengerWeb.Api.V1.MembershipControllerTest do
       assert json_response(conn, 403)["errors"] == @forbidden_error_code
     end
   end
+
+  describe "assign_admin/2" do
+    setup %{conn: conn, user: user} do
+      group = insert(:group)
+      insert(:membership, user: user, group: group, role: :admin)
+      membership = insert(:membership, group: group, role: :member)
+
+      path =
+        api_v1_group_membership_membership_path(
+          conn,
+          :assign_admin,
+          group.id,
+          membership.id
+        )
+
+      conn = put(conn, path)
+      %{assigns: %{membership: membership}} = conn
+
+      %{membership: membership, conn: conn, group: group}
+    end
+
+    test "returns a membership with admin member", c do
+      expected = render_json(MembershipView, "show.json", %{membership: c.membership})
+      assert json_response(c.conn, :ok) == expected
+    end
+
+    test "returns error when user is not authenticated", c do
+      conn = build_conn()
+
+      path =
+        api_v1_group_membership_membership_path(
+          conn,
+          :assign_admin,
+          c.group.id,
+          c.membership.id
+        )
+
+      conn = put(conn, path)
+
+      assert json_response(conn, 401)["errors"] == @unauthorized_error_code
+    end
+  end
+
+  describe "assign_admin/2 when current user is not creator/admin of the group" do
+    test "returns error", %{conn: conn, user: user} do
+      group = insert(:group)
+      insert(:membership, user: user, role: :admin)
+      membership = insert(:membership, group: group, role: :member)
+
+      path =
+        api_v1_group_membership_membership_path(
+          conn,
+          :assign_admin,
+          group.id,
+          membership.id
+        )
+
+      conn = put(conn, path)
+
+      assert json_response(conn, 403)["errors"] == @forbidden_error_code
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces a new function that lets the creator/admin to assign a member under his group as an admin.
- [x] Feature
- [x] REST

Reference to API Specification #8 