### PR TITLE
✨ Add REST endpoint: Rate Group

### DIFF
--- a/lib/travenger_web/controllers/api/v1/group_controller.ex
+++ b/lib/travenger_web/controllers/api/v1/group_controller.ex
@@ -11,10 +11,11 @@ defmodule TravengerWeb.Api.V1.GroupController do
   alias TravengerWeb.Api.V1.{
     FollowingView,
     GroupView,
-    MembershipView
+    MembershipView,
+    RatingView
   }
 
-  @require_auth_functions ~w(create join update invite delete follow)a
+  @require_auth_functions ~w(create join update invite delete follow rate)a
   @require_admin_functions ~w(invite update)a
   @require_creator_functions ~w(delete)a
 
@@ -95,6 +96,18 @@ defmodule TravengerWeb.Api.V1.GroupController do
       |> put_status(:ok)
       |> put_view(FollowingView)
       |> render("show.json", following: following)
+    end
+  end
+
+  def rate(%{assigns: %{user: user}} = conn, params) do
+    with params <- string_keys_to_atom(params),
+         %User{} = author <- Accounts.get_user(user.id),
+         {:ok, group} <- get_group(params.group_id),
+         {:ok, rating} <- Groups.add_rating(author, group, params) do
+      conn
+      |> put_status(:ok)
+      |> put_view(RatingView)
+      |> render("show.json", rating: rating)
     end
   end
 

--- a/lib/travenger_web/router.ex
+++ b/lib/travenger_web/router.ex
@@ -40,6 +40,7 @@ defmodule TravengerWeb.Router do
         post("/join", GroupController, :join)
         post("/invite", GroupController, :invite)
         post("/follow", GroupController, :follow)
+        post("/rate", GroupController, :rate)
 
         resources("/memberships", MembershipController) do
           put("/approve", MembershipController, :approve)

--- a/lib/travenger_web/views/api/v1/rating_view.ex
+++ b/lib/travenger_web/views/api/v1/rating_view.ex
@@ -1,0 +1,23 @@
+defmodule TravengerWeb.Api.V1.RatingView do
+  use TravengerWeb, :view
+
+  alias __MODULE__
+
+  alias TravengerWeb.Api.V1.{
+    GroupView,
+    UserView
+  }
+
+  def render("show.json", %{rating: rating}) do
+    %{data: render_one(rating, RatingView, "rating.json")}
+  end
+
+  def render("rating.json", %{rating: rating}) do
+    %{
+      id: rating.id,
+      author: render_one(rating.author, UserView, "user.json"),
+      followed_group: render_one(rating.group, GroupView, "group.json"),
+      rating: rating.rating
+    }
+  end
+end


### PR DESCRIPTION
This PR adds a REST endpoint for rating a group with route:
`POST api/v1/groups/{group_id}/rate`

Reference to Issue #8 