### PR TITLE
♻️[Chore] Refactor invite in groups to output invitation

### DIFF
--- a/lib/travenger_web/controllers/api/v1/group_controller.ex
+++ b/lib/travenger_web/controllers/api/v1/group_controller.ex
@@ -11,6 +11,7 @@ defmodule TravengerWeb.Api.V1.GroupController do
   alias TravengerWeb.Api.V1.{
     FollowingView,
     GroupView,
+    InvitationView,
     MembershipView,
     RatingView
   }
@@ -69,11 +70,11 @@ defmodule TravengerWeb.Api.V1.GroupController do
   def invite(conn, %{"group_id" => gid, "user_id" => uid}) do
     with %User{} = user <- Accounts.get_user(uid),
          %Group{} = group <- Groups.get_group(gid),
-         {:ok, membership} <- Groups.invite(user, group) do
+         {:ok, invitation} <- Groups.invite(user, group) do
       conn
       |> put_status(:ok)
-      |> put_view(MembershipView)
-      |> render("show.json", membership: membership)
+      |> put_view(InvitationView)
+      |> render("show.json", invitation: invitation)
     end
   end
 

--- a/test/travenger_web/controllers/api/v1/group_controller_test.exs
+++ b/test/travenger_web/controllers/api/v1/group_controller_test.exs
@@ -13,6 +13,7 @@ defmodule TravengerWeb.Api.V1.GroupControllerTest do
   alias TravengerWeb.Api.V1.{
     FollowingView,
     GroupView,
+    InvitationView,
     MembershipView,
     RatingView
   }
@@ -187,22 +188,22 @@ defmodule TravengerWeb.Api.V1.GroupControllerTest do
       params = %{user_id: insert(:user).id}
       path = api_v1_group_group_path(conn, :invite, group.id)
       conn = post(conn, path, params)
-      %{assigns: %{membership: membership}} = conn
+      %{assigns: %{invitation: invitation}} = conn
 
       %{
         conn: conn,
-        membership: membership,
+        invitation: invitation,
         user: user,
         group: group,
         params: params
       }
     end
 
-    test "returns a membership with invited status", %{
+    test "returns an invitation", %{
       conn: conn,
-      membership: m
+      invitation: inv
     } do
-      expected = render_json(MembershipView, "show.json", %{membership: m})
+      expected = render_json(InvitationView, "show.json", %{invitation: inv})
       assert json_response(conn, :ok) == expected
     end
 


### PR DESCRIPTION
This PR prevents groups to enlist a user in the membership record but instead just associate the user to a pending invitation.

Reference to Issue #8 