### PR TITLE
♻️ [Chore] Transfer membership schema under groups context

### DIFF
--- a/lib/travenger/accounts/accounts.ex
+++ b/lib/travenger/accounts/accounts.ex
@@ -12,11 +12,11 @@ defmodule Travenger.Accounts do
   alias Travenger.Accounts.{
     Following,
     Invitation,
-    Membership,
     User
   }
 
   alias Travenger.Groups
+  alias Travenger.Groups.Membership
   alias Travenger.Repo
 
   @doc """

--- a/lib/travenger/accounts/user.ex
+++ b/lib/travenger/accounts/user.ex
@@ -5,10 +5,8 @@ defmodule Travenger.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Travenger.Accounts.{
-    Following,
-    Membership
-  }
+  alias Travenger.Accounts.Following
+  alias Travenger.Groups.Membership
 
   alias Travenger.Posts.{
     Blog,

--- a/lib/travenger/groups/group.ex
+++ b/lib/travenger/groups/group.ex
@@ -8,10 +8,10 @@ defmodule Travenger.Groups.Group do
 
   alias Travenger.Accounts.{
     Invitation,
-    Membership,
     User
   }
 
+  alias Travenger.Groups.Membership
   alias Travenger.Groups.MembershipStatus
   alias Travenger.Posts.Event
 

--- a/lib/travenger/groups/groups.ex
+++ b/lib/travenger/groups/groups.ex
@@ -13,12 +13,12 @@ defmodule Travenger.Groups do
   alias Travenger.Accounts.{
     Following,
     Invitation,
-    Membership,
     User
   }
 
   alias Travenger.Groups.{
     Group,
+    Membership,
     MembershipStatus,
     Rating
   }

--- a/lib/travenger/groups/membership.ex
+++ b/lib/travenger/groups/membership.ex
@@ -1,4 +1,4 @@
-defmodule Travenger.Accounts.Membership do
+defmodule Travenger.Groups.Membership do
   @moduledoc """
   User Group association schema
   """

--- a/lib/travenger/groups/membership_status.ex
+++ b/lib/travenger/groups/membership_status.ex
@@ -5,7 +5,7 @@ defmodule Travenger.Groups.MembershipStatus do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Travenger.Accounts.Membership
+  alias Travenger.Groups.Membership
 
   @attrs ~w(status approved_at banned_at invited_at
   joined_at unbanned_at accepted_at removed_at)a

--- a/lib/travenger_web/controllers/api/v1/membership_controller.ex
+++ b/lib/travenger_web/controllers/api/v1/membership_controller.ex
@@ -3,8 +3,8 @@ defmodule TravengerWeb.Api.V1.MembershipController do
 
   import Travenger.Helpers.Utils
 
-  alias Travenger.Accounts.Membership
   alias Travenger.Groups
+  alias Travenger.Groups.Membership
   alias TravengerWeb.Api.V1.MembershipView
 
   @require_auth_functions ~w(approve assign_admin remove_admin remove_member)a

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -7,12 +7,12 @@ defmodule Travenger.Factory do
   alias Travenger.Accounts.{
     Following,
     Invitation,
-    Membership,
     User
   }
 
   alias Travenger.Groups.{
     Group,
+    Membership,
     MembershipStatus
   }
 

--- a/test/travenger/accounts/accounts_test.exs
+++ b/test/travenger/accounts/accounts_test.exs
@@ -5,7 +5,7 @@ defmodule Travenger.AccountsTest do
   import Travenger.Helpers.Queries
 
   alias Travenger.Accounts
-  alias Travenger.Accounts.Membership
+  alias Travenger.Groups.Membership
 
   @invalid_invitation_error "invalid invitation"
   @no_membership_error "no membership found"

--- a/test/travenger/accounts/membership_test.exs
+++ b/test/travenger/accounts/membership_test.exs
@@ -2,7 +2,7 @@ defmodule Travenger.Accounts.MembershipTest do
   use ExUnit.Case, async: true
 
   import Travenger.Factory
-  alias Travenger.Accounts.Membership
+  alias Travenger.Groups.Membership
 
   describe "changeset/2" do
     test "returns a valid changeset" do


### PR DESCRIPTION
This PR removes membership schema under accounts context and transfer it under groups context.

Reference Issue #8 